### PR TITLE
Medium Joint Speed default

### DIFF
--- a/sawyer_moveit_config/config/joint_limits.yaml
+++ b/sawyer_moveit_config/config/joint_limits.yaml
@@ -5,11 +5,11 @@ joint_limits:
     ## Acceleration Limits (rad/s^2) ##
     has_acceleration_limits: true
     ##           Slow Max            ##
-    max_velocity: 0.37
-    max_acceleration: 1.5
+    #max_velocity: 0.37
+    #max_acceleration: 1.5
     ##          Medium Max           ##
-    #max_velocity: 0.88
-    #max_acceleration: 3.5
+    max_velocity: 0.88
+    max_acceleration: 3.5
     ##           Fast Max            ##
     #max_velocity: 1.48
     #max_acceleration: 7
@@ -22,11 +22,11 @@ joint_limits:
     ## Acceleration Limits (rad/s^2) ##
     has_acceleration_limits: true
     ##           Slow Max            ##
-    max_velocity: 0.2825
-    max_acceleration: 1.5
+    #max_velocity: 0.2825
+    #max_acceleration: 1.5
     ##          Medium Max           ##
-    #max_velocity: 0.678
-    #max_acceleration: 2.5
+    max_velocity: 0.678
+    max_acceleration: 2.5
     ##           Fast Max            ##
     #max_velocity: 1.13
     #max_acceleration: 5
@@ -39,11 +39,11 @@ joint_limits:
     ## Acceleration Limits (rad/s^2) ##
     has_acceleration_limits: true
     ##           Slow Max            ##
-    max_velocity: 0.415
-    max_acceleration: 3.0
+    #max_velocity: 0.415
+    #max_acceleration: 3.0
     ##          Medium Max           ##
-    #max_velocity: 0.996
-    #max_acceleration: 5.0
+    max_velocity: 0.996
+    max_acceleration: 5.0
     ##           Fast Max            ##
     #max_velocity: 1.66
     #max_acceleration: 8
@@ -56,11 +56,11 @@ joint_limits:
     ## Acceleration Limits (rad/s^2) ##
     has_acceleration_limits: true
     ##           Slow Max            ##
-    max_velocity: 0.415
-    max_acceleration: 3.0
+    #max_velocity: 0.415
+    #max_acceleration: 3.0
     ##          Medium Max           ##
-    #max_velocity: 0.996
-    #max_acceleration: 5.0
+    max_velocity: 0.996
+    max_acceleration: 5.0
     ##           Fast Max            ##
     #max_velocity: 1.66
     #max_acceleration: 8
@@ -73,11 +73,11 @@ joint_limits:
     ## Acceleration Limits (rad/s^2) ##
     has_acceleration_limits: true
     ##           Slow Max            ##
-    max_velocity: 0.74
-    max_acceleration: 3.0
+    #max_velocity: 0.74
+    #max_acceleration: 3.0
     ##          Medium Max           ##
-    #max_velocity: 1.776
-    #max_acceleration: 5.0
+    max_velocity: 1.776
+    max_acceleration: 5.0
     ##           Fast Max            ##
     #max_velocity: 2.96
     #max_acceleration: 8
@@ -90,11 +90,11 @@ joint_limits:
     ## Acceleration Limits (rad/s^2) ##
     has_acceleration_limits: true
     ##           Slow Max            ##
-    max_velocity: 0.74
-    max_acceleration: 3.0
+    #max_velocity: 0.74
+    #max_acceleration: 3.0
     ##          Medium Max           ##
-    #max_velocity: 1.776
-    #max_acceleration: 5.0
+    max_velocity: 1.776
+    max_acceleration: 5.0
     ##           Fast Max            ##
     #max_velocity: 2.96
     #max_acceleration: 8
@@ -107,11 +107,11 @@ joint_limits:
     ## Acceleration Limits (rad/s^2) ##
     has_acceleration_limits: true
     ##           Slow Max            ##
-    max_velocity: 0.965
-    max_acceleration: 3.0
+    #max_velocity: 0.965
+    #max_acceleration: 3.0
     ##          Medium Max           ##
-    #max_velocity: 2.316
-    #max_acceleration: 5.0
+    max_velocity: 2.316
+    max_acceleration: 5.0
     ##           Fast Max            ##
     #max_velocity: 3.86
     #max_acceleration: 8


### PR DESCRIPTION
The slow speeds are too slow. This switches to "Medium" speeds for the default speed for Moveit.
