### PR TITLE
Resolves #6 Adds temp collision shape ignoring

### DIFF
--- a/sawyer_moveit_config/srdf/rethink_electric_gripper.srdf.xacro
+++ b/sawyer_moveit_config/srdf/rethink_electric_gripper.srdf.xacro
@@ -7,7 +7,11 @@
     <xacro:macro name="rethink_electric_gripper" params="side">
     <xacro:property name="gripper_side" value="${side[0]}" scope="local"/>
 
+    <disable_collisions link1="${side}_l6" link2="${side}_gripper_base" reason="Adjacent" />
+    <disable_collisions link1="${side}_gripper_base" link2="${side}_gripper" reason="Adjacent" />
+    <disable_collisions link1="${side}_gripper" link2="${side}_hand" reason="Adjacent" />
     <disable_collisions link1="${side}_hand" link2="${side}_gripper_base" reason="Adjacent" />
+    <xacro:if value="false"> <!-- Add these back in once articulated gripper is available -->
     <disable_collisions link1="${side}_hand" link2="${side}_connector_plate_base" reason="Adjacent" />
     <disable_collisions link1="${side}_hand" link2="${side}_electric_gripper_base" reason="Adjacent" />
 
@@ -55,5 +59,6 @@
     <disable_collisions link1="${gripper_side}_gripper_l_finger_tip" link2="${gripper_side}_gripper_r_finger_tip" reason="Never" />
     <disable_collisions link1="${gripper_side}_gripper_l_finger" link2="${gripper_side}_gripper_l_finger_tip" reason="Never" />
     <disable_collisions link1="${gripper_side}_gripper_r_finger" link2="${gripper_side}_gripper_r_finger_tip" reason="Never" />
+    </xacro:if>
     </xacro:macro>
 </robot>


### PR DESCRIPTION
Sawyer currently doesn't have articulated electric
gripper joints. This commit (to be reverted in the future)
removes all the articulated joint ignoring, in favor
of the simple fixed link shape ignoring. Tested with
an electric gripper plugged into the real robot.