### PR TITLE
Updates MoveGroup Execute to Service (for Indigo)

### DIFF
--- a/sawyer_moveit_config/launch/move_group.launch
+++ b/sawyer_moveit_config/launch/move_group.launch
@@ -53,7 +53,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-                                      move_group/MoveGroupExecuteTrajectoryAction
+                                      move_group/MoveGroupExecuteService
                                       move_group/MoveGroupKinematicsService
                                       move_group/MoveGroupMoveAction
                                       move_group/MoveGroupPickPlaceAction


### PR DESCRIPTION
To be compatible with ROS Indigo, we are keeping the `move_group/MoveGroupExecuteService`, despite the deprecation warning in Kinetic.