### PR TITLE
Adds sawyer-moveit rosinstall

### DIFF
--- a/sawyer_moveit.rosinstall
+++ b/sawyer_moveit.rosinstall
@@ -1,0 +1,20 @@
+- git:
+    local-name: intera_sdk
+    #uri: https://github.com/RethinkRobotics/intera_sdk.git
+    uri: git@github.com:RethinkRobotics/intera_sdk.git
+    version: release-5.0.4
+- git:
+    local-name: intera_common
+    #uri: https://github.com/RethinkRobotics/intera_common.git
+    uri: git@github.com:RethinkRobotics/intera_common.git
+    version: release-5.0.4
+- git:
+    local-name: sawyer_robot
+    #uri: https://github.com/RethinkRobotics/sawyer_robot.git
+    uri: git@github.com:RethinkRobotics/sawyer_robot.git
+    version: release-5.0.4
+- git:
+    local-name: sawyer_moveit
+    #uri: https://github.com/RethinkRobotics/sawyer_moveit.git
+    uri: git@github.com:RethinkRobotics/sawyer_moveit.git
+    version: release-5.0.4


### PR DESCRIPTION
This affords users the ability to checking out all
relevant SDK repos for sawyer's use with MoveIt framework.